### PR TITLE
Add third anniversary celebration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lucide-react": "^0.344.0",
         "mapbox-gl": "^2.15.0",
         "react": "^18.3.1",
+        "react-confetti": "^6.4.0",
         "react-dom": "^18.3.1",
         "react-map-gl": "^7.1.7",
         "react-photo-album": "^2.3.1",
@@ -3903,6 +3904,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -4562,6 +4578,12 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.344.0",
     "mapbox-gl": "^2.15.0",
     "react": "^18.3.1",
+    "react-confetti": "^6.4.0",
     "react-dom": "^18.3.1",
     "react-map-gl": "^7.1.7",
     "react-photo-album": "^2.3.1",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Heart, Clock, Image, MessageCircleHeart as MessageHeart, Map, ListTodo, BrainCircuit, Timer, Menu, X } from 'lucide-react';
+import { Heart, Clock, Image, Map, BrainCircuit, Menu, X } from 'lucide-react';
 
 const Navbar = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import dayjs from 'dayjs';
+import Confetti from 'react-confetti';
 
 const FIRST_DATE = '2022-06-03'; // First meeting
-const CONFESSION_DATE = '2023-02-14'; // First confession
 
 const Home = () => {
   const daysCount = dayjs().diff(FIRST_DATE, 'day');
+  const yearsCount = dayjs().diff(FIRST_DATE, 'year');
+  const showAnniversary = yearsCount >= 3;
 
   return (
     <div className="max-w-4xl mx-auto text-center">
@@ -28,6 +30,21 @@ const Home = () => {
             </h1>
           </div>
         </div>
+
+        {showAnniversary && (
+          <>
+            <Confetti numberOfPieces={200} recycle={false} />
+            <motion.div
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ duration: 0.6 }}
+              className="bg-pink-50 rounded-lg shadow-xl p-6 mb-8"
+            >
+              <h2 className="text-3xl font-bold text-pink-600 mb-2">Kỷ niệm 3 năm quen nhau!</h2>
+              <p className="text-gray-700">Cảm ơn em đã đồng hành cùng anh suốt 3 năm qua.</p>
+            </motion.div>
+          </>
+        )}
 
         <motion.div
           initial={{ scale: 0.9, opacity: 0 }}
@@ -61,6 +78,11 @@ const Home = () => {
             title="Khoảnh khắc đặc biệt"
             description="Ngày đầu tiên kiếm được Bus"
             date="15/03/2023"
+          />
+          <HighlightCard
+            title="Kỷ niệm 3 năm"
+            description="Tròn 3 năm yêu nhau rồi nè!"
+            date="03/06/2025"
           />
         </div>
       </motion.div>


### PR DESCRIPTION
## Summary
- add react-confetti to dependencies
- celebrate the third anniversary on the home page with a message and confetti
- fix linter errors in Navbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68415bf8997c8328912df9ce10289151