### PR TITLE
Fix Vercel build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lucide-react": "^0.344.0",
     "mapbox-gl": "^2.15.0",
     "react": "^18.3.1",
+    "react-confetti": "^6.4.0",
     "react-dom": "^18.3.1",
     "react-map-gl": "^7.1.7",
     "react-photo-album": "^2.3.1",
@@ -43,4 +44,3 @@
     "vite": "^5.4.2"
   }
 }
-

--- a/src/pages/Journey.tsx
+++ b/src/pages/Journey.tsx
@@ -31,7 +31,9 @@ const Journey = () => {
     latitude: 10.8231,
     zoom: 11
   });
-  const [mapLib, setMapLib] = useState<any>(null);
+  const [mapLib, setMapLib] = useState<null | typeof import('react-map-gl')>(
+    null
+  );
 
   useEffect(() => {
     let mounted = true;


### PR DESCRIPTION
## Summary
- add missing `react-confetti` dependency
- specify type of `mapLib` in `Journey` page to satisfy lint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684160a057308328b697641316b27325