### PR TITLE
Add pet photos page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ VITE_MAPBOX_TOKEN=your_mapbox_token
 
 The `.env` file is ignored by git and allows `src/pages/Journey.tsx` to read the token using `import.meta.env.VITE_MAPBOX_TOKEN`.
 
-A small React + Vite application built to celebrate the journey of a couple. It showcases a timeline, gallery and interactive quiz using Tailwind CSS for styling.
+A small React + Vite application built to celebrate the journey of a couple. It showcases a timeline, gallery, pet photos and interactive quiz using Tailwind CSS for styling.
 
 ## Prerequisites
 
@@ -35,7 +35,7 @@ npm run build
 ```
 src/
   components/     # Shared UI components (e.g. Navbar)
-  pages/          # React pages for timeline, gallery, map journey and quiz
+  pages/          # React pages for timeline, gallery, pet photos, map journey and quiz
   data/           # Static JSON used by the quiz
   index.css       # Tailwind CSS entry
   main.tsx        # App entry point that mounts React

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Timeline from './pages/Timeline';
 import Gallery from './pages/Gallery';
 import Journey from './pages/Journey';
 import Quiz from './pages/Quiz';
+import Pets from './pages/Pets';
 import { Analytics } from "@vercel/analytics/react";
 
 function App() {
@@ -19,6 +20,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/timeline" element={<Timeline />} />
             <Route path="/gallery" element={<Gallery />} />
+            <Route path="/pets" element={<Pets />} />
             {/* <Route path="/messages" element={<Messages />} /> */}
             <Route path="/journey" element={<Journey />} />
             {/* <Route path="/bucket-list" element={<BucketList />} /> */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Heart, Clock, Image, Map, BrainCircuit, Menu, X } from 'lucide-react';
+import { Heart, Clock, Image, Map, BrainCircuit, PawPrint, Menu, X } from 'lucide-react';
 
 const Navbar = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -37,6 +37,7 @@ const Navbar = () => {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <NavLink to="/timeline" icon={<Clock className="h-4 w-4" />} text="Timeline" onClick={toggleMenu} />
             <NavLink to="/gallery" icon={<Image className="h-4 w-4" />} text="Gallery" onClick={toggleMenu} />
+            <NavLink to="/pets" icon={<PawPrint className="h-4 w-4" />} text="Pets" onClick={toggleMenu} />
             <NavLink to="/journey" icon={<Map className="h-4 w-4" />} text="Journey" onClick={toggleMenu} />
             <NavLink to="/quiz" icon={<BrainCircuit className="h-4 w-4" />} text="Quiz" onClick={toggleMenu} />
           </div>

--- a/src/pages/Pets.tsx
+++ b/src/pages/Pets.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const petPhotos = [
+  {
+    src: 'https://res.cloudinary.com/drvpldkxq/image/upload/v1739498240/z6315816704368_b83ac6fabbda1e3e031d2b97c2d11a79_hlffoz.jpg',
+    width: 800,
+    height: 600,
+    title: 'Bus'
+  },
+  {
+    src: 'https://res.cloudinary.com/drvpldkxq/image/upload/v1739495975/20240716_122850_eha0sr.jpg',
+    width: 800,
+    height: 600,
+    title: 'Bus and Chuột'
+  },
+  {
+    src: 'https://res.cloudinary.com/drvpldkxq/image/upload/v1739495975/20250121_220816_un5vah.jpg',
+    width: 800,
+    height: 600,
+    title: 'Cả nhà'
+  },
+  {
+    src: 'https://res.cloudinary.com/drvpldkxq/image/upload/v1739495974/Locket_1737459647592_79_ege6ws.webp',
+    width: 800,
+    height: 600,
+    title: 'Nắng và Bus'
+  }
+];
+
+const Pets = () => {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="max-w-6xl mx-auto"
+    >
+      <h1 className="text-4xl font-bold text-center mb-8 text-gray-800">
+        Ảnh thú cưng
+      </h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {petPhotos.map((photo, index) => (
+          <img
+            key={index}
+            src={photo.src}
+            alt={photo.title}
+            className="w-full object-cover rounded-lg"
+            style={{ aspectRatio: photo.width / photo.height }}
+          />
+        ))}
+      </div>
+    </motion.div>
+  );
+};
+
+export default Pets;


### PR DESCRIPTION
## Summary
- create a new Pets page with cute pet images
- route `/pets` renders the new page
- add Pets link in the navbar
- document the pet page in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6846e7e7aa848328ad943d61c635549f